### PR TITLE
Add successor text to decomm actions

### DIFF
--- a/reports/2025-06-12/report.md
+++ b/reports/2025-06-12/report.md
@@ -176,6 +176,7 @@ At least the following will happen:
  - all issues closed
  - Replace CONTRIBUTING with thank you message
  - Message explaining archival added to README
+ - A successor message, if any, similar to: "At the time of archival (Date), the owners of repo foo/bar have requested to be listed as the successor fork. PSC is not affiliated with and cannot predict the future of this project."
  - move to chef-boneyard org
  - repo archived
 
@@ -205,4 +206,5 @@ We plan to use an estate-wide label, `oss-standards`, to tag PRs and Issues asso
 ### 7 - Ongoing Drift Detection
 
 We are developing an InSpec profile that describes the desired state of the repos, and will run it regularly, along with an GitHub Action component to self-scan.
+
 


### PR DESCRIPTION
After discussion in Community Advisory council, agreed to place a simple successor message, whose exact phrasing is undetermined.  We will determine a successor by a volunteer posting an issue on the repo that is to be decommisioned with the title Successor Fork Request, and listing the public fork in the description. Upon approval by Progress Chef, the README in the repo will be updated with a message and a link to the successor fork repo prior to archival.